### PR TITLE
Refactor: Update CI to only deploy main and then run migrations upon …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,26 @@ orbs:
   ruby: circleci/ruby@1.4.0
   heroku: circleci/heroku@1.2.6
 
+workflows:
+  build_and_test:
+    jobs:
+      - build
+      - checking
+      - test:
+          requires:
+            - build 
+  heroku_deploy:
+    jobs:
+      - build
+      - heroku/deploy-via-git: # Use the pre-configured job, deploy-via-git
+          requires:
+            - build
+          filters:
+            branches:
+              only: main
+          post-steps:
+            - run: heroku run rake db:migrate -a news-app-fe
+
 jobs:
   build:
     docker:
@@ -21,15 +41,15 @@ jobs:
     docker:
       - image: cimg/ruby:2.7.4-node
       - environment:
-          POSTGRES_DB: news_app_fe_test
-          POSTGRES_USER: news_app_fe
+          POSTGRES_DB: news-app-fe_test
+          POSTGRES_USER: news-app-fe
           POSTGRES_PASSWORD: ''
         image: cimg/postgres:14.1
     environment:
       BUNDLE_JOBS: 3
       BUNDLE_RETRY: 3
       PGHOST: 127.0.0.1
-      PGUSER: news_app_fe
+      PGUSER: news-app-fe
       PGPASSWORD: ''
       RAILSENV: test
     parallelism: 3
@@ -47,18 +67,3 @@ jobs:
       - ruby/rspec-test:
           label: RSpec tests
           include: spec/**/*_spec.rb
-
-workflows:
-  version: 2
-  build_and_test:
-    jobs:
-      - build
-      - checking
-      - test:
-          requires:
-            - build
-  heroku_deploy:
-    jobs:
-      - heroku/deploy-via-git:
-          post-steps:
-            - run: heroku run rake db:migrate -a news-app-fe  


### PR DESCRIPTION
Update to CI/CD. This should stop the issues with the Heroku check failing. It's been tested on the BE to ensure it's behaving as expected. 

Expected Behavior: 
- User commits to a branch and then pushes said branch to GitHub
- CI runs a Heroku check but makes no changes unless pushed directly to Main
- User opens a PR
- When PR is being merged into Main, Heroku deploys automatically and then runs the db:migrate command as well
- User enjoys the glorious success of CircleCI and boasts to their friends how easy it was to use knowing it was a complete cluster for nearly 2 full weeks