### PR TITLE
Add special character considerations for search

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -20,7 +20,7 @@ before_action :require_user
   private
     def valid_characters_v2(str)
       # You know what, god bless Dennis Ritchie, but I hate Regex
-      !(str =~ /[ \$ \: \; \* \! \# \@ \% \^ \& \( \) \? \> \< \. \[ \] \\ \/ ]/)
+      !(str =~ /[ \$ \: \; \* \! \# \@ \% \^ \& \( \) \? \> \< \. \[ \] \\ \/ \{ \} ]/)
     end
 
     # User gives us a keyword

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -18,6 +18,17 @@ before_action :require_user
   end
 
   private
+    def valid_characters_v2(str)
+      # You know what, god bless Dennis Ritchie, but I hate Regex
+      !(str =~ /[ \$ \: \; \* \! \# \@ \% \^ \& \( \) \? \> \< \. \[ \] \\ \/ ]/)
+    end
+
+    # User gives us a keyword
+    # keyword -> backend
+    # keyword.contains($:;*, etc...) -> backend breaks
+    # find_valid_characters(keyword)
+    # find_valid_characters(keyword) = true IF keyword.does_not_contain ["$", ":", ";", "*", "!", "#", "@", "%", "^", "&", "(", ")", "?", ">", "<", ".", "'", "[", "]"]
+
     def valid_characters(keyword)
       array = ["$", ":", ";", "*", "!", "#", "@", "%", "^", "&", "(", ")", "?", ">", "<", ".", "'", "[", "]"]
       valid = true

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -6,6 +6,9 @@ before_action :require_user
     if keyword == ""
       redirect_to('/dashboard')
       flash.notice = "Field cannot be blank"
+    elsif valid_characters(keyword) == false
+      redirect_to('/dashboard')
+      flash.notice = "Search contained improper characters please try again!"
     else
       topic = TopicFacade.get_articles(keyword)
       article_array = topic.articles
@@ -13,4 +16,17 @@ before_action :require_user
       @name = topic.topic
     end
   end
+
+  private
+    def valid_characters(keyword)
+      array = ["$", ":", ";", "*", "!", "#", "@", "%", "^", "&", "(", ")", "?", ">", "<", ".", "'", "[", "]"]
+      valid = true
+      empty_array = []
+      array.each do |character|
+        if keyword.include?(character)
+          valid = false
+        end
+      end
+      valid
+    end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -21,7 +21,6 @@ before_action :require_user
     def valid_characters(keyword)
       array = ["$", ":", ";", "*", "!", "#", "@", "%", "^", "&", "(", ")", "?", ">", "<", ".", "'", "[", "]"]
       valid = true
-      empty_array = []
       array.each do |character|
         if keyword.include?(character)
           valid = false


### PR DESCRIPTION
So what we did here was make sure that our app doesn't crash whenever we use special characters in the topic search. Where we were before, everytime we typed in !@#$%^&*()><?":}{ or any of those keys, it would break. I added a private method and another conditional in the controller and we messed with it alot in local host and it seemed to work great! Lemme know if it "Looks good!".